### PR TITLE
fix: fix IP validation for allowing only IPv4 Addresses

### DIFF
--- a/backend/OBSController.py
+++ b/backend/OBSController.py
@@ -28,7 +28,6 @@ class OBSController(obsws):
             # in a bad-push state.
             if addr.version == 6:
                 raise ValueError()
-            return True
         except ValueError:
             return False
 

--- a/backend/OBSController.py
+++ b/backend/OBSController.py
@@ -26,7 +26,7 @@ class OBSController(obsws):
             # previous implementations. Again, probably the wrong thing
             # long-term, but implementing this way to mitigate risk while we're
             # in a bad-push state.
-            if not addr.version == ipaddress.IPv4Address.version:
+            if addr.version == 6:
                 raise ValueError()
             return True
         except ValueError:


### PR DESCRIPTION
This fixes an issue when checking if an IP is IPv4 or IPv6, which currently raises a ValueError when inputting _any_ IP that is not localhost or 127.0.0.1. This will allow IPv4 addresses to be used, but it will also allow IPv4 addresses other than the host's. Implementing a check to see if an IP belongs to the host is beyond my knowledge.