### PR TITLE
Hide errors on success

### DIFF
--- a/actions/Filter/FilterBase.py
+++ b/actions/Filter/FilterBase.py
@@ -51,6 +51,7 @@ class FilterBase(OBSActionBase, MixinBase, ABC):
             self.show_for_state(State.DISABLED)
 
     def show_for_state(self, state: State):
+        self.hide_error()
         if state == self.current_state:
             return
 

--- a/actions/InputDial/InputDial.py
+++ b/actions/InputDial/InputDial.py
@@ -70,6 +70,7 @@ class InputDial(OBSActionBase):
         self.volume = self.db_to_volume(status["volume"])
 
         # Now render the button
+        self.hide_error()
         image = "input_muted.png" if self.muted else "input_unmuted.png"
         label = f"{self.volume}%"
 

--- a/actions/InputMute/InputMuteBase.py
+++ b/actions/InputMute/InputMuteBase.py
@@ -86,6 +86,7 @@ class InputMuteBase(OBSActionBase, MixinBase, ABC):
         State.DISABLED: Input unmuted
         State.ENABLED: Input muted
         """
+        self.hide_error()
         if state == self.current_state:
             return
 

--- a/actions/SceneItem/SceneItem.py
+++ b/actions/SceneItem/SceneItem.py
@@ -65,6 +65,7 @@ class SceneItemBase(OBSActionBase, MixinBase, ABC):
             self.show_for_state(State.DISABLED)
 
     def show_for_state(self, state: State):
+        self.hide_error()
         if state == self.current_state:
             return
 

--- a/actions/ToggleRecord/ToggleRecord.py
+++ b/actions/ToggleRecord/ToggleRecord.py
@@ -49,6 +49,7 @@ class ToggleRecord(OBSActionBase):
         2: Paused
         3: Stopping in progress
         """
+        self.hide_error()
         if state in [1, 2]:
             self.show_rec_time()
 

--- a/actions/ToggleReplayBuffer/ToggleReplayBuffer.py
+++ b/actions/ToggleReplayBuffer/ToggleReplayBuffer.py
@@ -48,6 +48,7 @@ class ToggleReplayBuffer(OBSActionBase):
         0: Replay Buffer Turned Off
         1: Replay Buffer Turned On
         """
+        self.hide_error()
         if state == self.current_state:
             return
         

--- a/actions/ToggleStream/ToggleStream.py
+++ b/actions/ToggleStream/ToggleStream.py
@@ -48,6 +48,7 @@ class ToggleStream(OBSActionBase):
         1: Streaming Connected
         2: Streaming Reconnecting
         """
+        self.hide_error()
         if state in [1, 2]:
             self.show_stream_time()
         

--- a/actions/ToggleStudioMode/ToggleStudioMode.py
+++ b/actions/ToggleStudioMode/ToggleStudioMode.py
@@ -48,6 +48,7 @@ class ToggleStudioMode(OBSActionBase):
         0: Studio Mode Turned Off
         1: Studio Mode Turned On
         """
+        self.hide_error()
         if state == self.current_state:
             return
         

--- a/actions/ToggleVirtualCamera/ToggleVirtualCamera.py
+++ b/actions/ToggleVirtualCamera/ToggleVirtualCamera.py
@@ -48,6 +48,7 @@ class ToggleVirtualCamera(OBSActionBase):
         0: Virtual Camera Turned Off
         1: Virtual Camera Turned On
         """
+        self.hide_error()
         if state == self.current_state:
             return
         


### PR DESCRIPTION
If OBS is not open, or gets closed, when StreamController is running, we default to `self.show_error()`. However, if OBS is opened after StreamController is opened, we never hide the error. This change adds `self.hide_error()` to the `show_for_state()` function that exists in most actions, as once reaching this point, we can be sure that an media image should be set on the action