### PR TITLE
Initialize OBS actions with blank selections by default

### DIFF
--- a/actions/Filter/FilterBase.py
+++ b/actions/Filter/FilterBase.py
@@ -111,18 +111,16 @@ class FilterBase(OBSActionBase, MixinBase, ABC):
         while self.filter_model.get_n_items() > 0:
             self.filter_model.remove(0)
 
+        # Prepend blank options
+        self.scene_model.append("")
+        self.filter_model.append("")
+
         # Load model
         if self.backend.get_connected():
             scenes = self.backend.get_scene_names()
-            if scenes is None:
-                return
-            for scene in scenes:
-                self.scene_model.append(scene)
-            # Ensure selection is made if there's only one scene
-            if len(scenes) == 1:
-                self.get_settings()["scene"] = scenes[0]
-                self.scene_row.set_selected(0)
-                self.load_filters_for_scene(scenes[0])
+            if scenes is not None:
+                for scene in scenes:
+                    self.scene_model.append(scene)
 
         self.connect_signals()
 
@@ -131,6 +129,11 @@ class FilterBase(OBSActionBase, MixinBase, ABC):
         while self.filter_model.get_n_items() > 0:
             self.filter_model.remove(0)
 
+        self.filter_model.append("")
+
+        if not scene_name:
+            return
+
         if self.backend.get_connected():
             filters = self.backend.get_source_filters(scene_name)
             if filters is None:
@@ -138,9 +141,6 @@ class FilterBase(OBSActionBase, MixinBase, ABC):
                 return
             for item in filters:
                 self.filter_model.append(item.get("filterName"))
-            # Ensure selection is made if there's only one item
-            if len(filters) == 1:
-                self.filter_row.set_selected(0)
 
     def load_configs(self):
         self.load_config_values()
@@ -148,36 +148,60 @@ class FilterBase(OBSActionBase, MixinBase, ABC):
     def load_config_values(self):
         self.disconnect_signals()
         settings = self.get_settings()
-        for i, scene_name in enumerate(self.scene_model):
-            if scene_name.get_string() == settings.get("scene"):
-                self.scene_row.set_selected(i)
-                self.load_filters_for_scene(scene_name.get_string())
-                for j, item_name in enumerate(self.filter_model):
-                    if item_name.get_string() == settings.get("filter"):
-                        self.filter_row.set_selected(j)
-                        break
-                self.connect_signals()
-                return
+        configured_scene = settings.get("scene")
+        configured_filter = settings.get("filter")
 
-        self.scene_row.set_selected(Gtk.INVALID_LIST_POSITION)
-        self.filter_row.set_selected(Gtk.INVALID_LIST_POSITION)
+        scene_found = False
+        if configured_scene:
+            for i, scene_name in enumerate(self.scene_model):
+                if scene_name.get_string() == configured_scene:
+                    self.scene_row.set_selected(i)
+                    self.load_filters_for_scene(configured_scene)
+                    scene_found = True
+                    break
+        
+        if scene_found:
+            filter_found = False
+            if configured_filter:
+                for j, item_name in enumerate(self.filter_model):
+                    if item_name.get_string() == configured_filter:
+                        self.filter_row.set_selected(j)
+                        filter_found = True
+                        break
+            if not filter_found:
+                self.filter_row.set_selected(0)
+        else:
+            self.scene_row.set_selected(0)
+            self.load_filters_for_scene("")
+            self.filter_row.set_selected(0)
+
         self.connect_signals()
 
     def on_scene_selected(self, *args):
         settings = self.get_settings()
         selected_index_scene = self.scene_row.get_selected()
-        if selected_index_scene != Gtk.INVALID_LIST_POSITION:
+        if selected_index_scene == Gtk.INVALID_LIST_POSITION or selected_index_scene < 0 or selected_index_scene >= self.scene_model.get_n_items():
+            scene_name = ""
+        else:
             scene_name = self.scene_model[selected_index_scene].get_string()
-            settings["scene"] = scene_name
-            self.set_settings(settings)
-            self.load_filters_for_scene(scene_name)
+        
+        settings["scene"] = scene_name
+        settings["filter"] = ""
+        self.set_settings(settings)
+        
+        self.disconnect_signals()
+        self.load_filters_for_scene(scene_name)
+        self.filter_row.set_selected(0)
+        self.connect_signals()
 
     def on_filter_selected(self, *args):
         settings = self.get_settings()
         selected_index_item = self.filter_row.get_selected()
-        if selected_index_item != Gtk.INVALID_LIST_POSITION:
+        if selected_index_item == Gtk.INVALID_LIST_POSITION or selected_index_item < 0 or selected_index_item >= self.filter_model.get_n_items():
+            settings["filter"] = ""
+        else:
             settings["filter"] = self.filter_model[selected_index_item].get_string()
-            self.set_settings(settings)
+        self.set_settings(settings)
 
     def on_key_down(self):
         if not self.plugin_base.get_connected():

--- a/actions/InputDial/InputDial.py
+++ b/actions/InputDial/InputDial.py
@@ -121,14 +121,15 @@ class InputDial(OBSActionBase):
         while self.input_model.get_n_items() > 0:
             self.input_model.remove(0)
 
+        # Prepend blank option
+        self.input_model.append("")
+
         # Load model
         if self.backend.get_connected():
             inputs = self.backend.get_inputs()
-            if inputs is None:
-                self.set_media(media_path=os.path.join(self.plugin_base.PATH, "assets", "error.png"))
-                return
-            for input in inputs:
-                self.input_model.append(input)
+            if inputs is not None:
+                for input in inputs:
+                    self.input_model.append(input)
 
         self.connect_signals()
 
@@ -138,19 +139,29 @@ class InputDial(OBSActionBase):
     def load_selected_device(self):
         self.disconnect_signals()
         settings = self.get_settings()
+        configured_input = settings.get("input")
+
+        if not configured_input:
+            self.input_row.set_selected(0)
+            self.connect_signals()
+            return
+
         for i, input_name in enumerate(self.input_model):
-            if input_name.get_string() == settings.get("input"):
+            if input_name.get_string() == configured_input:
                 self.input_row.set_selected(i)
                 self.connect_signals()
                 return
             
-        self.input_row.set_selected(Gtk.INVALID_LIST_POSITION)
+        self.input_row.set_selected(0)
         self.connect_signals()
     
     def on_input_change(self, *args):
         settings = self.get_settings()
         selected_index = self.input_row.get_selected()
-        settings["input"] = self.input_model[selected_index].get_string()
+        if selected_index == Gtk.INVALID_LIST_POSITION or selected_index < 0 or selected_index >= self.input_model.get_n_items():
+            settings["input"] = ""
+        else:
+            settings["input"] = self.input_model[selected_index].get_string()
         self.set_settings(settings)
 
     def event_callback(self, event: InputEvent, data: dict = None):

--- a/actions/InputMute/InputMuteBase.py
+++ b/actions/InputMute/InputMuteBase.py
@@ -124,14 +124,15 @@ class InputMuteBase(OBSActionBase, MixinBase, ABC):
         while self.input_model.get_n_items() > 0:
             self.input_model.remove(0)
 
+        # Prepend blank option
+        self.input_model.append("")
+
         # Load model
         if self.backend.get_connected():
             inputs = self.backend.get_inputs()
-            if inputs is None:
-                self.set_media(media_path=os.path.join(self.plugin_base.PATH, "assets", "error.png"))
-                return
-            for input in inputs:
-                self.input_model.append(input)
+            if inputs is not None:
+                for input in inputs:
+                    self.input_model.append(input)
 
         self.connect_signals()
 
@@ -140,18 +141,28 @@ class InputMuteBase(OBSActionBase, MixinBase, ABC):
 
     def load_selected_device(self):
         self.disconnect_signals()
+        configured_input = self.input
+
+        if not configured_input:
+            self.input_row.set_selected(0)
+            self.connect_signals()
+            return
+
         for i, input_name in enumerate(self.input_model):
-            if input_name.get_string() == self.input:
+            if input_name.get_string() == configured_input:
                 self.input_row.set_selected(i)
                 self.connect_signals()
                 return
 
-        self.input_row.set_selected(Gtk.INVALID_LIST_POSITION)
+        self.input_row.set_selected(0)
         self.connect_signals()
 
     def on_mute_input(self, *args):
         selected_index = self.input_row.get_selected()
-        self.input = self.input_model[selected_index].get_string()
+        if selected_index == Gtk.INVALID_LIST_POSITION or selected_index < 0 or selected_index >= self.input_model.get_n_items():
+            self.input = ""
+        else:
+            self.input = self.input_model[selected_index].get_string()
 
     def assert_valid_state_for_update(self):
         if not self.plugin_base.get_connected():

--- a/actions/SceneItem/SceneItem.py
+++ b/actions/SceneItem/SceneItem.py
@@ -110,18 +110,16 @@ class SceneItemBase(OBSActionBase, MixinBase, ABC):
         while self.item_model.get_n_items() > 0:
             self.item_model.remove(0)
 
+        # Prepend blank options
+        self.scene_model.append("")
+        self.item_model.append("")
+
         # Load model
         if self.backend.get_connected():
             scenes = self.backend.get_scene_names()
-            if scenes is None:
-                return
-            for scene in scenes:
-                self.scene_model.append(scene)
-            # Ensure selection is made if there's only one scene
-            if len(scenes) == 1:
-                self.get_settings()["scene"] = scenes[0]
-                self.scene_row.set_selected(0)
-                self.load_items_for_scene(scenes[0])
+            if scenes is not None:
+                for scene in scenes:
+                    self.scene_model.append(scene)
 
         self.connect_signals()
 
@@ -130,6 +128,11 @@ class SceneItemBase(OBSActionBase, MixinBase, ABC):
         while self.item_model.get_n_items() > 0:
             self.item_model.remove(0)
 
+        self.item_model.append("")
+
+        if not scene_name:
+            return
+
         if self.backend.get_connected():
             items = self.backend.get_scene_items(scene_name)
             if items is None:
@@ -137,9 +140,6 @@ class SceneItemBase(OBSActionBase, MixinBase, ABC):
                 return
             for item in items:
                 self.item_model.append(item)
-            # Ensure selection is made if there's only one item
-            if len(items) == 1:
-                self.item_row.set_selected(0)
 
     def load_configs(self):
         self.load_selected_device()
@@ -147,36 +147,60 @@ class SceneItemBase(OBSActionBase, MixinBase, ABC):
     def load_selected_device(self):
         self.disconnect_signals()
         settings = self.get_settings()
-        for i, scene_name in enumerate(self.scene_model):
-            if scene_name.get_string() == settings.get("scene"):
-                self.scene_row.set_selected(i)
-                self.load_items_for_scene(scene_name.get_string())
-                for j, item_name in enumerate(self.item_model):
-                    if item_name.get_string() == settings.get("item"):
-                        self.item_row.set_selected(j)
-                        break
-                self.connect_signals()
-                return
+        configured_scene = settings.get("scene")
+        configured_item = settings.get("item")
 
-        self.scene_row.set_selected(Gtk.INVALID_LIST_POSITION)
-        self.item_row.set_selected(Gtk.INVALID_LIST_POSITION)
+        scene_found = False
+        if configured_scene:
+            for i, scene_name in enumerate(self.scene_model):
+                if scene_name.get_string() == configured_scene:
+                    self.scene_row.set_selected(i)
+                    self.load_items_for_scene(configured_scene)
+                    scene_found = True
+                    break
+        
+        if scene_found:
+            item_found = False
+            if configured_item:
+                for j, item_name in enumerate(self.item_model):
+                    if item_name.get_string() == configured_item:
+                        self.item_row.set_selected(j)
+                        item_found = True
+                        break
+            if not item_found:
+                self.item_row.set_selected(0)
+        else:
+            self.scene_row.set_selected(0)
+            self.load_items_for_scene("")
+            self.item_row.set_selected(0)
+
         self.connect_signals()
 
     def on_scene_selected(self, *args):
         settings = self.get_settings()
         selected_index_scene = self.scene_row.get_selected()
-        if selected_index_scene != Gtk.INVALID_LIST_POSITION:
+        if selected_index_scene == Gtk.INVALID_LIST_POSITION or selected_index_scene < 0 or selected_index_scene >= self.scene_model.get_n_items():
+            scene_name = ""
+        else:
             scene_name = self.scene_model[selected_index_scene].get_string()
-            settings["scene"] = scene_name
-            self.set_settings(settings)
-            self.load_items_for_scene(scene_name)
+        
+        settings["scene"] = scene_name
+        settings["item"] = ""
+        self.set_settings(settings)
+        
+        self.disconnect_signals()
+        self.load_items_for_scene(scene_name)
+        self.item_row.set_selected(0)
+        self.connect_signals()
 
     def on_item_selected(self, *args):
         settings = self.get_settings()
         selected_index_item = self.item_row.get_selected()
-        if selected_index_item != Gtk.INVALID_LIST_POSITION:
+        if selected_index_item == Gtk.INVALID_LIST_POSITION or selected_index_item < 0 or selected_index_item >= self.item_model.get_n_items():
+            settings["item"] = ""
+        else:
             settings["item"] = self.item_model[selected_index_item].get_string()
-            self.set_settings(settings)
+        self.set_settings(settings)
 
     def on_key_down(self):
         if not self.plugin_base.get_connected():

--- a/actions/SwitchScene/SwitchScene.py
+++ b/actions/SwitchScene/SwitchScene.py
@@ -57,13 +57,15 @@ class SwitchScene(OBSActionBase):
         while self.scene_model.get_n_items() > 0:
             self.scene_model.remove(0)
 
+        # Prepend blank option
+        self.scene_model.append("")
+
         # Load model
         if self.backend.get_connected():
             scenes = self.backend.get_scene_names()
-            if scenes is None:
-                return
-            for scene in scenes:
-                self.scene_model.append(scene)
+            if scenes is not None:
+                for scene in scenes:
+                    self.scene_model.append(scene)
 
         self.connect_signals()
 
@@ -73,19 +75,29 @@ class SwitchScene(OBSActionBase):
     def load_selected_device(self):
         self.disconnect_signals()
         settings = self.get_settings()
+        configured_scene = settings.get("scene")
+
+        if not configured_scene:
+            self.scene_row.set_selected(0)
+            self.connect_signals()
+            return
+
         for i, scene_name in enumerate(self.scene_model):
-            if scene_name.get_string() == settings.get("scene"):
+            if scene_name.get_string() == configured_scene:
                 self.scene_row.set_selected(i)
                 self.connect_signals()
                 return
             
-        self.scene_row.set_selected(Gtk.INVALID_LIST_POSITION)
+        self.scene_row.set_selected(0)
         self.connect_signals()
 
     def on_change_scene(self, *args):
         settings = self.get_settings()
         selected_index = self.scene_row.get_selected()
-        settings["scene"] = self.scene_model[selected_index].get_string()
+        if selected_index == Gtk.INVALID_LIST_POSITION or selected_index < 0 or selected_index >= self.scene_model.get_n_items():
+            settings["scene"] = ""
+        else:
+            settings["scene"] = self.scene_model[selected_index].get_string()
         self.set_settings(settings)
 
     def on_key_down(self):

--- a/actions/SwitchSceneCollection/SwitchSceneCollection.py
+++ b/actions/SwitchSceneCollection/SwitchSceneCollection.py
@@ -53,13 +53,15 @@ class SwitchSceneCollection(OBSActionBase):
         while self.scene_collection_model.get_n_items() > 0:
             self.scene_collection_model.remove(0)
 
+        # Prepend blank option
+        self.scene_collection_model.append("")
+
         # Load model
         if self.backend.get_connected():
             sceneCollections = self.backend.get_scene_collections()
-            if sceneCollections is None:
-                return
-            for sceneCollection in sceneCollections:
-                self.scene_collection_model.append(sceneCollection)
+            if sceneCollections is not None:
+                for sceneCollection in sceneCollections:
+                    self.scene_collection_model.append(sceneCollection)
 
         self.connect_signals()
 
@@ -69,19 +71,29 @@ class SwitchSceneCollection(OBSActionBase):
     def load_selected_device(self):
         self.disconnect_signals()
         settings = self.get_settings()
+        configured_collection = settings.get("scene_collection")
+
+        if not configured_collection:
+            self.scene_collection_row.set_selected(0)
+            self.connect_signals()
+            return
+
         for i, scene_collection_name in enumerate(self.scene_collection_model):
-            if scene_collection_name.get_string() == settings.get("scene_collection"):
+            if scene_collection_name.get_string() == configured_collection:
                 self.scene_collection_row.set_selected(i)
                 self.connect_signals()
                 return
             
-        self.scene_collection_row.set_selected(Gtk.INVALID_LIST_POSITION)
+        self.scene_collection_row.set_selected(0)
         self.connect_signals()
 
     def on_change_scene_collection(self, *args):
         settings = self.get_settings()
         selected_index = self.scene_collection_row.get_selected()
-        settings["scene_collection"] = self.scene_collection_model[selected_index].get_string()
+        if selected_index == Gtk.INVALID_LIST_POSITION or selected_index < 0 or selected_index >= self.scene_collection_model.get_n_items():
+            settings["scene_collection"] = ""
+        else:
+            settings["scene_collection"] = self.scene_collection_model[selected_index].get_string()
         self.set_settings(settings)
 
     def on_key_down(self):


### PR DESCRIPTION
Updated SwitchScene, FilterBase, SceneItemBase, InputMuteBase, InputDial, and SwitchSceneCollection actions to prepend an empty string to their list models so they initialize with a blank option by default. Handled fallback behavior to default to index 0 (the blank option) when no configuration exists, and guarded callback signals to safely handle index validation and reset dependent settings.